### PR TITLE
PCR_Extend implementation

### DIFF
--- a/client_demo_compromised.py
+++ b/client_demo_compromised.py
@@ -1,0 +1,67 @@
+from client import *
+from tpm2_util import tpm_pcr_extend
+import TPM2.Tpm as Tpm2
+
+
+def run_compromised_client():
+    parser = argparse.ArgumentParser(
+        description="PV204 NoisyTPM - this is a part of team project for PV204. \
+                                                    Client app can communicate with server using Noise framework \
+                                                    and authenticate via TPM. Please see \
+                                                    'https://github.com/Matej4545/PV204-NoisyTPM/' for more info."
+    )
+    parser.add_argument(
+        "-s",
+        "--server",
+        dest="server",
+        metavar="IP",
+        type=str,
+        default="localhost",
+        help="An IP address or hostname of the server.",
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        dest="port",
+        metavar="PORT",
+        type=int,
+        default=5555,
+        help="A port where the server is listening.",
+    )
+    parser.add_argument(
+        "-m",
+        "--message",
+        metavar="MESSAGE",
+        dest="message",
+        type=str,
+        nargs="+",
+        help="Specify message as argument. For interactive session please omit.",
+    )
+    parser.add_argument(
+        "-r --register",
+        dest="register",
+        action="store_true",
+        default=False,
+        help="If you are not authenticated or running the app first time, you will need to register.",
+    )
+    args = parser.parse_args()
+
+    # demo part simulating a change in one PCR
+    hacker_tpm = Tpm2.Tpm(True)
+    hacker_tpm.connect()
+    tpm_pcr_extend(hacker_tpm, 0, "Hack the Planet!")  # 0 is BIOS hash
+    hacker_tpm.close()
+
+    try:
+        message = "" if args.message is None else "".join(args.message).strip()
+        client = Client(args.server.strip(), args.port)
+        if args.register:
+            client.register()
+        client.run(message)
+    except Exception as e:
+        print("An error occurred! Quitting app.")
+        print(e)
+
+
+if __name__ == "__main__":
+    run_compromised_client()

--- a/tpm2_demo.py
+++ b/tpm2_demo.py
@@ -16,12 +16,14 @@ def helper_bitmap_to_pcr_nums(bitmap: List[int]) -> List[int]:
 
 def tpm2_demo():
     """A TPM2 demo showcasing some of its functionalities.
-    Uses a real TPM by default.
+    Uses a TPM simulator by default.
     """
+    # set to True to use a TCP TPM. In that case a simulator needs to be running
+    # uses a real TPM when set to False
+    use_sim = True
+
     # host="127.0.0.1", port=2321
-    # set 'useSimulator' to True to use a TCP TPM. In that case a simulator needs to be running
-    # use a real TPM when set to False
-    tpm = Tpm2.Tpm(useSimulator=False)
+    tpm = Tpm2.Tpm(useSimulator=use_sim)
 
     # TPM object needs to connect to a real TPM or a simulator
     try:
@@ -107,6 +109,16 @@ def tpm2_demo():
         if i % 8 == 7:
             sep = ""
             print()
+
+    # we can also extend the PCR hash
+    # only for a simulator, OS will most likely block this for a real TPM to preserve integrity
+    if use_sim:
+        pcr23 = [0, 0, 0b10000000]
+        hash23 = tu.get_pcr_values(tpm, pcr23)[0]
+        print("\nPCR3 before:", hash23.hex())
+        tu.tpm_pcr_extend(tpm, 23, "RIP Dan Kaminsky")
+        hash23 = tu.get_pcr_values(tpm, pcr23)[0]
+        print("PCR3 after: ", hash23.hex())
 
 
 if __name__ == "__main__":

--- a/tpm2_demo.py
+++ b/tpm2_demo.py
@@ -120,6 +120,9 @@ def tpm2_demo():
         hash23 = tu.get_pcr_values(tpm, pcr23)[0]
         print("PCR3 after: ", hash23.hex())
 
+    # end the communication with the TPM
+    tpm.close()
+
 
 if __name__ == "__main__":
     tpm2_demo()

--- a/tpm2_util.py
+++ b/tpm2_util.py
@@ -131,6 +131,21 @@ def tpm_self_verify_signature(tpm: Tpm, aik: TPM_HANDLE, sig: TPMU_SIGNATURE, da
     return True
 
 
+def tpm_pcr_extend(tpm: Tpm, pcr: int, value: str) -> bool:
+    """Extends 'pcr' with 'value'."""
+    hs = Crypto.tpmAlgToPy(TPM_ALG_ID.SHA1)()
+    hs.update(bytes(value, "UTF-8"))
+
+    digest = TPMT_HA(TPM_ALG_ID.SHA1, hs.digest())
+
+    try:
+        tpm.PCR_Extend(TPM_HANDLE.pcr(pcr), [digest])
+    except TpmError as tpm_e:
+        print(tpm_e)
+        return False
+    return True
+
+
 def get_random_bytes(tpm: Tpm, n: int) -> List[int]:
     """Get 'n' random bytes."""
     rnd_bytes = tpm.GetRandom(n)


### PR DESCRIPTION
Added a simple function to extend a chosen PCR as well as a demo showcase. Note that demo now uses a simulator by default. Extending PCR values is usually blocked for a real TPM in order to preserve integrity. Extend is not triggered for a real TPM demo.